### PR TITLE
Production deployment

### DIFF
--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -121,6 +121,7 @@ export default async function HomePage({
                   {
                     document: {
                       ...text,
+                      coverUrl: text.coverImageUrl,
                       primaryNames: text.primaryNameTranslations,
                     },
                   } as any
@@ -142,6 +143,7 @@ export default async function HomePage({
                   {
                     document: {
                       ...text,
+                      coverUrl: text.coverImageUrl,
                       primaryNames: text.primaryNameTranslations,
                     },
                   } as any
@@ -163,6 +165,7 @@ export default async function HomePage({
                   {
                     document: {
                       ...text,
+                      coverUrl: text.coverImageUrl,
                       primaryNames: text.primaryNameTranslations,
                     },
                   } as any

--- a/src/app/[locale]/t/[bookId]/[pageNumber]/page.tsx
+++ b/src/app/[locale]/t/[bookId]/[pageNumber]/page.tsx
@@ -3,13 +3,10 @@ import { notFound } from "next/navigation";
 import ReaderContent from "../_components/reader-content";
 import SidebarResizer from "../_components/sidebar/sidebar-resizer";
 import ReaderSidebar from "../_components/sidebar";
-import { MobileSidebarProvider } from "../_components/mobile-sidebar-provider";
-import { tabs } from "../_components/sidebar/tabs";
 import { getBookPage } from "@/lib/api";
 import ReaderNavigation from "../_components/reader-navigation";
 import { getMetadata } from "@/lib/seo";
 import { navigation } from "@/lib/urls";
-import Paginator from "./paginator";
 
 export const generateMetadata = async ({
   params: { bookId, pageNumber },
@@ -38,7 +35,7 @@ export const generateMetadata = async ({
     index: parsedNumber - 1,
   });
 
-  if (!response.book) return {};
+  if (!response) return {};
 
   const book = response.book;
 
@@ -79,18 +76,15 @@ async function SidebarContent({
     notFound();
   }
 
-  let response: Awaited<ReturnType<typeof getBookPage>> | null = null;
-  try {
-    response = await getBookPage(bookId, {
-      locale: pathLocale,
-      versionId,
-      includeBook: true,
-      fields: ["pdf", "headings", "indices", "publication_details"],
-      index: parsedNumber - 1,
-    });
-  } catch (e) {}
+  const response = await getBookPage(bookId, {
+    locale: pathLocale,
+    versionId,
+    includeBook: true,
+    fields: ["pdf", "headings", "indices", "publication_details"],
+    index: parsedNumber - 1,
+  });
 
-  if (response === null) {
+  if (!response) {
     notFound();
   }
 
@@ -105,26 +99,8 @@ async function SidebarContent({
     notFound();
   }
 
-  const mobile = tabs.map((tab) => {
-    return (
-      <MobileSidebarProvider
-        key={tab.id}
-        icon={<tab.icon className="h-5 w-5 dark:text-white" />}
-        tabId={tab.id}
-        bookSlug={bookId}
-        versionId={versionId}
-        bookResponse={response as any}
-      />
-    );
-  });
-
   return (
     <SidebarResizer
-      // secondNav={
-      //   <div className="relative flex w-full items-center justify-between bg-slate-50 dark:bg-card lg:hidden">
-      //     {mobile}
-      //   </div>
-      // }
       sidebar={
         <ReaderSidebar
           bookSlug={bookId}
@@ -140,7 +116,6 @@ async function SidebarContent({
         <ReaderContent
           response={response}
           currentPage={parsedNumber}
-          // slug={bookId}
           isSinglePage
         />
       </article>

--- a/src/app/[locale]/t/[bookId]/_components/reader-content/reader-page.tsx
+++ b/src/app/[locale]/t/[bookId]/_components/reader-content/reader-page.tsx
@@ -118,6 +118,8 @@ const useFetchPage = (
         size: perPage,
       });
 
+      if (!response) return null;
+
       return (response.content as any).pages as DefaultPages;
     },
     enabled: !isSinglePage && !shouldUseDefaultPages,

--- a/src/app/[locale]/t/[bookId]/page.tsx
+++ b/src/app/[locale]/t/[bookId]/page.tsx
@@ -3,8 +3,6 @@ import { notFound } from "next/navigation";
 import ReaderContent from "./_components/reader-content";
 import SidebarResizer from "./_components/sidebar/sidebar-resizer";
 import ReaderSidebar from "./_components/sidebar";
-import { MobileSidebarProvider } from "./_components/mobile-sidebar-provider";
-import { tabs } from "./_components/sidebar/tabs";
 import { ArrowUpRightIcon, FileQuestionIcon } from "lucide-react";
 import { getTranslations } from "next-intl/server";
 import { Button } from "@/components/ui/button";
@@ -40,7 +38,7 @@ export const generateMetadata = async ({
     size: READER_PAGINATION_SIZE,
   });
 
-  if (!response.book) return {};
+  if (!response) return {};
 
   const book = response.book;
 
@@ -77,18 +75,15 @@ export default async function SidebarContent({
   const pathLocale = await getPathLocale();
   const t = await getTranslations("reader");
 
-  let response: Awaited<ReturnType<typeof getBook>> | null = null;
-  try {
-    response = await getBook(bookId, {
-      locale: pathLocale,
-      versionId,
-      includeBook: true,
-      fields: ["pdf", "headings", "indices", "publication_details"],
-      size: READER_PAGINATION_SIZE,
-    });
-  } catch (e) {}
+  const response = await getBook(bookId, {
+    locale: pathLocale,
+    versionId,
+    includeBook: true,
+    fields: ["pdf", "headings", "indices", "publication_details"],
+    size: READER_PAGINATION_SIZE,
+  });
 
-  if (response === null) {
+  if (!response) {
     notFound();
   }
 
@@ -101,26 +96,8 @@ export default async function SidebarContent({
     pages = null;
   }
 
-  const mobile = tabs.map((tab) => {
-    return (
-      <MobileSidebarProvider
-        key={tab.id}
-        icon={<tab.icon className="h-5 w-5 dark:text-white" />}
-        tabId={tab.id}
-        bookSlug={bookId}
-        versionId={versionId}
-        bookResponse={response as any}
-      />
-    );
-  });
-
   return (
     <SidebarResizer
-      // secondNav={
-      //   <div className="relative flex w-full items-center justify-between bg-slate-50 dark:bg-card lg:hidden">
-      //     {mobile}
-      //   </div>
-      // }
       sidebar={
         <ReaderSidebar
           bookSlug={bookId}

--- a/src/components/book-search-result/index.tsx
+++ b/src/components/book-search-result/index.tsx
@@ -58,14 +58,18 @@ const BookSearchResult = ({
 
         <Link href={navigation.books.reader(document.slug)} prefetch={prefetch}>
           <div className={cn("overflow-hidden rounded-md bg-muted")}>
-            <CloudflareImage
-              src={`https://assets.usul.ai/covers/${document.slug}.png`}
-              alt={title}
-              width={320}
-              height={460}
-              className="aspect-[1600/2300] w-full object-cover"
-              placeholder="empty"
-            />
+            {document.coverUrl ? (
+              <CloudflareImage
+                src={document.coverUrl}
+                alt={title}
+                width={320}
+                height={460}
+                className="aspect-[1600/2300] w-full object-cover"
+                placeholder="empty"
+              />
+            ) : (
+              <div className="aspect-[1600/2300] w-full bg-muted" />
+            )}
           </div>
 
           <div className="mt-2">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -27,16 +27,22 @@ const prepareParams = (params: ApiBookParams) => {
 };
 
 export const getBook = cache(async (slug: string, params: ApiBookParams) => {
-  const response = await fetch(
-    `${API_BASE}/book/${slug}${prepareParams(params)}`,
-    {
-      headers: {
-        "Content-Type": "application/json",
+  try {
+    const response = await fetch(
+      `${API_BASE}/book/${slug}${prepareParams(params)}`,
+      {
+        headers: {
+          "Content-Type": "application/json",
+        },
       },
-    },
-  );
+    );
 
-  return response.json() as Promise<ApiBookResponse>;
+    if (!response.ok || response.status >= 300) return null;
+
+    return response.json() as Promise<ApiBookResponse>;
+  } catch (e) {
+    return null;
+  }
 });
 
 const prepareBookPageParams = (params: ApiBookPageParams) => {
@@ -53,16 +59,22 @@ const prepareBookPageParams = (params: ApiBookPageParams) => {
 
 export const getBookPage = cache(
   async (slug: string, params: ApiBookPageParams) => {
-    const response = await fetch(
-      `${API_BASE}/book/page/${slug}${prepareBookPageParams(params)}`,
-      {
-        headers: {
-          "Content-Type": "application/json",
+    try {
+      const response = await fetch(
+        `${API_BASE}/book/page/${slug}${prepareBookPageParams(params)}`,
+        {
+          headers: {
+            "Content-Type": "application/json",
+          },
         },
-      },
-    );
+      );
 
-    return response.json() as Promise<ApiBookPageResponse>;
+      if (!response.ok || response.status >= 300) return null;
+
+      return response.json() as Promise<ApiBookPageResponse>;
+    } catch (e) {
+      return null;
+    }
   },
 );
 

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -12,6 +12,7 @@ export type BookDocument = {
   _popularity: number;
 
   versions: PrismaJson.BookVersion[];
+  coverUrl?: string;
   genreIds: string[];
   // these are derived from the author
   author: {


### PR DESCRIPTION
- fix reader page: show not-found.tsx when the books is not found or an error occurred while fetching
- use `text.coverUrl` instead of a static url based on the slug