### PR TITLE
Refactor transliterations

### DIFF
--- a/src/app/[locale]/(entityPages)/author/[authorSlug]/page.tsx
+++ b/src/app/[locale]/(entityPages)/author/[authorSlug]/page.tsx
@@ -96,11 +96,7 @@ async function AuthorPage({ routeParams, searchParams }: AuthorPageProps) {
     },
   });
 
-  const primaryName =
-    pathLocale === "en" && author.transliteration
-      ? author.transliteration
-      : author.primaryName;
-
+  const primaryName = author.primaryName;
   const secondaryName = author.secondaryName;
 
   const locations = author.locations

--- a/src/app/[locale]/(entityPages)/collections/[slug]/collection-books/book-search.tsx
+++ b/src/app/[locale]/(entityPages)/collections/[slug]/collection-books/book-search.tsx
@@ -78,17 +78,8 @@ export default function BookSearch({
     setCurrentPage(page);
   };
 
-  const title = (book: BookDocument) => {
-    return book.transliteration && pathLocale === "en"
-      ? book.transliteration
-      : book.primaryName;
-  };
-
-  const authorName = (book: BookDocument) => {
-    return book.author.transliteration && pathLocale === "en"
-      ? book.author.transliteration
-      : book.author.primaryName;
-  };
+  const title = (book: BookDocument) => book.primaryName;
+  const authorName = (book: BookDocument) => book.author.primaryName;
 
   const showList =
     focusedState.value && (debouncedValue.length > 2 || isLoading);

--- a/src/app/[locale]/advanced-search/search-result.tsx
+++ b/src/app/[locale]/advanced-search/search-result.tsx
@@ -1,9 +1,9 @@
+import type { SearchCorpusResponse } from "@/server/services/chat";
 import { Badge } from "@/components/ui/badge";
 import { removeDiacritics } from "@/lib/diacritics";
 import { usePathLocale } from "@/lib/locale/utils";
 import { navigation } from "@/lib/urls";
 import { Link } from "@/navigation";
-import type { SearchCorpusResponse } from "@/server/services/chat";
 import { useTranslations } from "next-intl";
 
 export default function AdvancedSearchResult({

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -53,12 +53,11 @@ const bookToTypesenseBook = (
     id: book.id,
     slug: book.slug,
     authorId: book.authorId,
-    transliteration: book.transliteration ?? undefined,
 
-    primaryName: getPrimaryLocalizedText(
-      book.primaryNameTranslations,
-      pathLocale,
-    )!,
+    primaryName:
+      pathLocale === "en" && book.transliteration
+        ? book.transliteration
+        : getPrimaryLocalizedText(book.primaryNameTranslations, pathLocale)!,
     secondaryName:
       getSecondaryLocalizedText(book.primaryNameTranslations, pathLocale) ??
       undefined,
@@ -85,12 +84,14 @@ const bookToTypesenseBook = (
       type: "author",
       id: book.authorId,
       slug: book.author.slug,
-      transliteration: book.author.transliteration ?? undefined,
       year: book.author.year ?? -1,
-      primaryName: getPrimaryLocalizedText(
-        book.author.primaryNameTranslations,
-        pathLocale,
-      )!,
+      primaryName:
+        pathLocale === "en" && book.author.transliteration
+          ? book.author.transliteration
+          : getPrimaryLocalizedText(
+              book.author.primaryNameTranslations,
+              pathLocale,
+            )!,
       secondaryName:
         getSecondaryLocalizedText(
           book.author.primaryNameTranslations,

--- a/src/app/_components/navbar/search-bar/item.tsx
+++ b/src/app/_components/navbar/search-bar/item.tsx
@@ -5,7 +5,6 @@ import {
   getGlobalDocumentHref,
   getGlobalDocumentLocalizedTypeKey,
 } from "@/lib/global-search";
-import { usePathLocale } from "@/lib/locale/utils";
 import { Link } from "@/navigation";
 import { useTranslations } from "next-intl";
 
@@ -17,15 +16,12 @@ function SearchBarItem({
   document: GlobalSearchDocument;
 }) {
   const href = getGlobalDocumentHref(document);
-  const pathLocale = usePathLocale();
+
   const t = useTranslations("entities");
   const Comp = (href ? Link : "button") as any;
   const type = document.type;
 
-  const primaryName =
-    pathLocale === "en" && document.transliteration && type !== "genre"
-      ? document.transliteration
-      : document.primaryName;
+  const primaryName = document.primaryName;
   const secondaryName = document.secondaryName;
 
   const finalPrimaryName = primaryName ?? secondaryName;

--- a/src/components/author-search-result.tsx
+++ b/src/components/author-search-result.tsx
@@ -16,11 +16,7 @@ export default function AuthorSearchResult({
   const t = useTranslations();
   const pathLocale = usePathLocale();
 
-  const transliteration =
-    result.transliteration && pathLocale === "en"
-      ? result.transliteration
-      : undefined;
-  const primaryName = transliteration ?? result.primaryName;
+  const primaryName = result.primaryName;
   const primaryOtherNames = result.otherNames;
   const secondaryOtherNames = result.secondaryOtherNames;
 

--- a/src/components/book-search-result/index.tsx
+++ b/src/components/book-search-result/index.tsx
@@ -26,18 +26,11 @@ export default function BookSearchResult({
 
   const { author } = result;
 
-  const title =
-    result.transliteration && pathLocale === "en"
-      ? result.transliteration
-      : result.primaryName;
+  const title = result.primaryName;
 
   const secondaryTitle = result.secondaryName;
 
-  const authorName = (
-    author.transliteration && pathLocale === "en"
-      ? author.transliteration
-      : author.primaryName
-  ) as string | undefined;
+  const authorName = author.primaryName as string | undefined;
 
   const authorSecondaryName = author.secondaryName;
 

--- a/src/components/genre-search-result.tsx
+++ b/src/components/genre-search-result.tsx
@@ -1,5 +1,4 @@
 import type { GenreDocument } from "@/types/genre";
-import { usePathLocale } from "@/lib/locale/utils";
 import { navigation } from "@/lib/urls";
 import { useTranslations } from "next-intl";
 
@@ -13,12 +12,6 @@ export default function GenreSearchResult({
   prefetch?: boolean;
 }) {
   const t = useTranslations("entities");
-  const locale = usePathLocale();
-
-  const transliteration =
-    result.transliteration && locale === "en"
-      ? result.transliteration
-      : undefined;
 
   return (
     <EntityCard
@@ -26,7 +19,6 @@ export default function GenreSearchResult({
       prefetch={prefetch}
       primaryTitle={result.primaryName}
       secondaryTitle={result.secondaryName}
-      primarySubtitle={transliteration}
       tags={[t("x-texts", { count: result.booksCount })]}
     />
   );

--- a/src/components/global-search-result.tsx
+++ b/src/components/global-search-result.tsx
@@ -3,7 +3,6 @@ import {
   getGlobalDocumentHref,
   getGlobalDocumentLocalizedTypeKey,
 } from "@/lib/global-search";
-import { getPathLocale } from "@/lib/locale/server";
 import { Link } from "@/navigation";
 import { getTranslations } from "next-intl/server";
 
@@ -17,16 +16,11 @@ export default async function GlobalSearchResult({
   prefetch?: boolean;
 }) {
   const t = await getTranslations("entities");
-  const pathLocale = await getPathLocale();
 
   const href = getGlobalDocumentHref(result);
   const type = result.type;
 
-  const primaryName =
-    pathLocale === "en" && result.transliteration && type !== "genre"
-      ? result.transliteration
-      : result.primaryName;
-
+  const primaryName = result.primaryName;
   const secondaryName = result.secondaryName;
 
   const finalPrimaryName = primaryName ?? secondaryName;

--- a/src/types/api/author.ts
+++ b/src/types/api/author.ts
@@ -5,7 +5,6 @@ import type { ApiRegion } from "./region";
 export interface ApiAuthor {
   id: string;
   slug: string;
-  transliteration: string;
   year: number;
   numberOfBooks: number;
   primaryName: string;
@@ -13,11 +12,9 @@ export interface ApiAuthor {
   secondaryName: string;
   secondaryOtherNames: string[];
   bio: string;
-
   locations: {
     id: string;
     slug: string;
-    transliteration: string | null;
     name: string;
     secondaryName: string;
     type: LocationType;

--- a/src/types/api/book.ts
+++ b/src/types/api/book.ts
@@ -32,7 +32,6 @@ type BookDetails = {
   author: {
     id: string;
     slug: string;
-    transliteration: string;
     year?: number | null;
     numberOfBooks: number;
     primaryName: string;
@@ -41,7 +40,6 @@ type BookDetails = {
     secondaryOtherNames?: string[] | null;
     bio: string;
   };
-  transliteration: string;
   aiSupported: boolean;
   aiVersion: string;
   keywordSupported: boolean;
@@ -55,7 +53,6 @@ type BookDetails = {
   genres: {
     id: string;
     slug: string;
-    transliteration: string;
     numberOfBooks: number;
     name: string;
     secondaryName: string;

--- a/src/types/api/genre.ts
+++ b/src/types/api/genre.ts
@@ -3,7 +3,6 @@ import type { CollectionCardProps } from "@/components/ui/collection-card";
 export interface ApiGenre {
   id: string;
   slug: string;
-  transliteration: string;
   numberOfBooks: number;
   name: string;
   secondaryName: string;

--- a/src/types/api/location.ts
+++ b/src/types/api/location.ts
@@ -1,7 +1,6 @@
 export interface ApiLocation {
   id: string;
   slug: string;
-  transliteration: string | null;
   name: string;
   secondaryName: string;
   type: "Died" | "Born" | "Visited" | "Resided";

--- a/src/types/api/region.ts
+++ b/src/types/api/region.ts
@@ -1,7 +1,6 @@
 export interface ApiRegion {
   id: string;
   slug: string;
-  transliteration: string | null;
   name: string;
   secondaryName: string;
   currentName: string;

--- a/src/types/author.ts
+++ b/src/types/author.ts
@@ -1,22 +1,13 @@
-// import type { LocalizedArrayEntry, LocalizedEntry } from "./localized-entry";
-
 export type AuthorDocument = {
   type: "author";
 
   id: string;
   slug: string;
   year: number;
-  transliteration?: string;
   primaryName: string;
   secondaryName?: string;
   otherNames?: string[];
   secondaryOtherNames?: string[];
-
-  // primaryNames: LocalizedEntry[];
-  // otherNames: LocalizedArrayEntry[];
-  // bios: LocalizedEntry[];
-  // _nameVariations: string[];
-  // _popularity: number;
 
   regions: string[]; // region slugs
   geographies: string[];

--- a/src/types/book.ts
+++ b/src/types/book.ts
@@ -5,7 +5,6 @@ export type BookDocument = {
   id: string;
   slug: string;
   authorId: string;
-  transliteration?: string;
 
   primaryName: string;
   secondaryName?: string;
@@ -23,7 +22,6 @@ export type BookDocument = {
     type: "author";
     id: string;
     slug: string;
-    transliteration?: string;
     year: number;
     primaryName: string;
     secondaryName?: string;

--- a/src/types/genre.ts
+++ b/src/types/genre.ts
@@ -1,16 +1,11 @@
-// import type { LocalizedEntry } from "./localized-entry";
-
 export type GenreDocument = {
   type: "genre";
 
   id: string;
   slug: string;
-  transliteration?: string;
+
   primaryName: string;
   secondaryName?: string;
-
-  // nameTranslations: LocalizedEntry[];
-  // _popularity: number;
 
   booksCount: number;
 };

--- a/src/types/global-search-document.ts
+++ b/src/types/global-search-document.ts
@@ -1,22 +1,14 @@
 import type { AuthorDocument } from "./author";
 
-// import type { LocalizedArrayEntry, LocalizedEntry } from "./localized-entry";
-
 export type GlobalSearchDocument = {
   id: string;
   slug: string;
   type: "author" | "book" | "genre" | "region";
 
-  transliteration?: string;
   primaryName: string;
   secondaryName?: string;
   otherNames?: string[];
 
-  // primaryNames: LocalizedEntry[];
-  // otherNames: LocalizedArrayEntry[];
-
-  // _nameVariations?: string[];
-  // _popularity?: number;
   author?: Omit<AuthorDocument, "books" | "booksCount" | "geographies">;
   year?: number;
   booksCount?: number;


### PR DESCRIPTION
Refactor book and author name handling across components to remove transliteration logic, simplifying name retrieval to use primaryName directly. Update related types to remove transliteration properties for consistency.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified logic for displaying names and titles by always using the primary name, removing all locale-based transliteration checks across author, book, and genre components.
* **Chores**
  * Removed the transliteration property from API response types and internal type definitions for authors, books, genres, locations, and regions.
* **Style**
  * Cleaned up imports and removed unused code related to transliteration and locale handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->